### PR TITLE
switching from pyqt5 to pyside6 as python bindings for the Qt library

### DIFF
--- a/QNodeEditor/clipboard/clipboard.py
+++ b/QNodeEditor/clipboard/clipboard.py
@@ -5,7 +5,10 @@ Module containing class handling clipboard interaction for node scenes
 from typing import TYPE_CHECKING
 import json
 
-from PyQt5.QtWidgets import QApplication
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError:
+    from PyQt5.QtWidgets import QApplication
 
 from QNodeEditor.graphics.node import NodeGraphics
 from QNodeEditor.graphics.edge import EdgeGraphics

--- a/QNodeEditor/dialog.py
+++ b/QNodeEditor/dialog.py
@@ -10,10 +10,16 @@ from typing import Optional, Any
 import traceback
 from functools import partial
 
-from PyQt5.QtWidgets import (QDialog, QPushButton, QWidget, QHBoxLayout, QVBoxLayout, QLabel,
-                             QMessageBox, QTextEdit, QProgressBar)
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFontMetrics, QKeyEvent
+try:
+    from PySide6.QtWidgets import (QDialog, QPushButton, QWidget, QHBoxLayout, QVBoxLayout, QLabel,
+                                   QMessageBox, QTextEdit, QProgressBar)
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QFontMetrics, QKeyEvent
+except ImportError:
+    from PyQt5.QtWidgets import (QDialog, QPushButton, QWidget, QHBoxLayout, QVBoxLayout, QLabel,
+                                 QMessageBox, QTextEdit, QProgressBar)
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtGui import QFontMetrics, QKeyEvent
 
 from QNodeEditor.editor import NodeEditor
 from QNodeEditor.themes import ThemeType, DarkTheme

--- a/QNodeEditor/edge.py
+++ b/QNodeEditor/edge.py
@@ -8,7 +8,11 @@ determine the shape of the edge. Contains a graphics object that exists in a
 # pylint: disable = no-name-in-module
 from typing import Optional, TYPE_CHECKING
 
-from PyQt5.QtCore import QObject, pyqtSignal
+try:
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import QObject
+except ImportError:
+    from PyQt5.QtCore import pyqtSignal, QObject
 
 from QNodeEditor.graphics.edge import EdgeGraphics, BezierEdgeGraphics, DirectEdgeGraphics
 from QNodeEditor.socket import Socket
@@ -82,9 +86,12 @@ class Edge(QObject, metaclass=ObjectMeta):
         """
         super().__init__()
         # Get socket if start or end is an Entry
-        if isinstance(start, Entry):
+        # For reasons unknown Entry does not have _abc_impl which prevents the usage of isinstance().
+        # It might be related to the usage of a custom metaclass but further investigation is needed.
+        # The below workaround works due to Qt adding a QMetaObject to all its classes which can be compared.
+        if start is not None and Entry.staticMetaObject == start.staticMetaObject.superClass():
             start: Socket = start.socket
-        if isinstance(end, Entry):
+        if end is not None and Entry.staticMetaObject == end.staticMetaObject.superClass():
             end: Socket = end.socket
 
         # If the scene is not provided, try to derive it from the start/end sockets

--- a/QNodeEditor/editor.py
+++ b/QNodeEditor/editor.py
@@ -8,8 +8,15 @@ which can be edited at runtime by the user.
 import os
 from typing import Type, TYPE_CHECKING, overload
 
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
-from PyQt5.QtCore import pyqtSignal, Qt
+try:
+    from PySide6.QtWidgets import QWidget, QVBoxLayout
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import Qt
+except ImportError:
+    import warnings
+    warnings.warn("No Installation of PySide6 found falling back to PyQt5")
+    from PyQt5.QtWidgets import QWidget, QVBoxLayout
+    from PyQt5.QtCore import pyqtSignal, Qt
 
 from QNodeEditor import NodeScene, NodeView
 from QNodeEditor.themes import ThemeType, DarkTheme
@@ -59,7 +66,7 @@ class NodeEditor(QWidget):
             If set to True, multiple edges can be connected to the same node input. Otherwise, only
             a single edge can be connected to any input.
         """
-        super().__init__(parent)
+        super().__init__() # parent=parent
 
         # Create widget layout
         layout = QVBoxLayout()

--- a/QNodeEditor/entries/combo_box.py
+++ b/QNodeEditor/entries/combo_box.py
@@ -7,6 +7,11 @@ from QNodeEditor.entry import Entry
 from QNodeEditor.widgets import ComboBox
 from QNodeEditor.themes import ThemeType, DarkTheme
 
+try:
+    from PySide6.QtWidgets import QComboBox
+except ImportError:
+    from PyQt5.QtWidgets import QComboBox
+
 
 class ComboBoxEntry(Entry):
     """

--- a/QNodeEditor/entries/labeled.py
+++ b/QNodeEditor/entries/labeled.py
@@ -2,9 +2,15 @@
 Module containing class for an entry with a simple name label
 """
 # pylint: disable = no-name-in-module
-from PyQt5.QtWidgets import QHBoxLayout, QWidget
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QFontMetrics
+
+try:
+    from PySide6.QtWidgets import QHBoxLayout, QWidget
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QFontMetrics
+except ImportError:
+    from PyQt5.QtWidgets import QHBoxLayout, QWidget
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtGui import QFontMetrics
 
 from QNodeEditor.entry import Entry
 from QNodeEditor.widgets import Label

--- a/QNodeEditor/entries/text_box.py
+++ b/QNodeEditor/entries/text_box.py
@@ -3,8 +3,12 @@ Module containing class for an entry with a text box
 """
 from typing import Optional
 
-from PyQt5.QtWidgets import QCompleter
-from PyQt5.QtGui import QValidator
+try:
+    from PySide6.QtWidgets import QCompleter
+    from PySide6.QtGui import QValidator
+except ImportError:
+    from PyQt5.QtWidgets import QCompleter
+    from PyQt5.QtGui import QValidator
 
 from QNodeEditor.entry import Entry
 from QNodeEditor.widgets import TextBox

--- a/QNodeEditor/entry.py
+++ b/QNodeEditor/entry.py
@@ -8,8 +8,13 @@ socket, depending on the set entry type.
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Optional, Any
 
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import Qt, QObject, pyqtSignal
+try:
+    from PySide6.QtWidgets import QWidget
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import QObject, Qt
+except ImportError:
+    from PyQt5.QtWidgets import QWidget
+    from PyQt5.QtCore import pyqtSignal, QObject, Qt
 
 from QNodeEditor.widgets import EmptyWidget
 from QNodeEditor.socket import Socket

--- a/QNodeEditor/graphics/cutter.py
+++ b/QNodeEditor/graphics/cutter.py
@@ -4,9 +4,14 @@ Module containing extension of QGraphicsItem for graphics of an edge cutting lin
 # pylint: disable = no-name-in-module, C0103
 from typing import TYPE_CHECKING
 
-from PyQt5.QtWidgets import QGraphicsItem
-from PyQt5.QtCore import QPointF, Qt, QRectF, QPoint
-from PyQt5.QtGui import QPen, QPainter, QPainterPath, QPolygonF
+try:
+    from PySide6.QtWidgets import QGraphicsItem
+    from PySide6.QtCore import Qt, QPoint, QRectF, QPointF
+    from PySide6.QtGui import QPainter, QPen, QPainterPath, QPolygonF
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsItem
+    from PyQt5.QtCore import Qt, QPoint, QRectF, QPointF
+    from PyQt5.QtGui import QPainter, QPen, QPainterPath, QPolygonF
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 if TYPE_CHECKING:

--- a/QNodeEditor/graphics/edge.py
+++ b/QNodeEditor/graphics/edge.py
@@ -5,9 +5,14 @@ Module containing extensions of QGraphicsPathItem representing various edge type
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 
-from PyQt5.QtWidgets import QGraphicsPathItem, QGraphicsItem
-from PyQt5.QtCore import Qt, QRectF, QPointF, QPoint
-from PyQt5.QtGui import QPainter, QPen, QPainterPath
+try:
+    from PySide6.QtWidgets import QGraphicsPathItem, QGraphicsItem
+    from PySide6.QtCore import Qt, QRectF, QPointF, QPoint
+    from PySide6.QtGui import QPainter, QPen, QPainterPath
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsPathItem, QGraphicsItem
+    from PyQt5.QtCore import Qt, QRectF, QPointF, QPoint
+    from PyQt5.QtGui import QPainter, QPen, QPainterPath
 
 from QNodeEditor.entry import Entry
 from QNodeEditor.themes import ThemeType, DarkTheme

--- a/QNodeEditor/graphics/entry.py
+++ b/QNodeEditor/graphics/entry.py
@@ -4,11 +4,13 @@ Module containing extension of QGraphicsProxyWidget representing node entries..
 # pylint: disable = no-name-in-module
 from typing import TYPE_CHECKING, Optional
 
-from PyQt5.QtWidgets import QGraphicsProxyWidget, QGraphicsSceneHoverEvent
-from PyQt5.QtCore import QPoint
-from PyQt5.QtGui import QEnterEvent
+try:
+    from PySide6.QtWidgets import QGraphicsProxyWidget, QGraphicsSceneHoverEvent
+    from PySide6.QtGui import QEnterEvent
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsProxyWidget, QGraphicsSceneHoverEvent
+    from PyQt5.QtGui import QEnterEvent
 
-from QNodeEditor.widgets.value_box import ValueBox
 if TYPE_CHECKING:
     from QNodeEditor.entry import Entry
 

--- a/QNodeEditor/graphics/node.py
+++ b/QNodeEditor/graphics/node.py
@@ -2,13 +2,20 @@
 Module containing extension of QGraphicsItem representing a node.
 """
 # pylint: disable = no-name-in-module, C0103
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from PyQt5.QtWidgets import QGraphicsItem, QGraphicsDropShadowEffect, QGraphicsTextItem
-from PyQt5.QtCore import QRectF, Qt, QPointF, QVariant
-from PyQt5.QtGui import QPainter, QPainterPath, QColor, QBrush, QPen, QFontMetrics
+try:
+    from PySide6.QtWidgets import QGraphicsItem, QGraphicsDropShadowEffect, QGraphicsTextItem
+    from PySide6.QtCore import QRectF, Qt, QPointF
+    from PySide6.QtGui import QPainter, QPainterPath, QColor, QBrush, QPen, QFontMetrics
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsItem, QGraphicsDropShadowEffect, QGraphicsTextItem
+    from PyQt5.QtCore import QRectF, Qt, QPointF
+    from PyQt5.QtGui import QPainter, QPainterPath, QColor, QBrush, QPen, QFontMetrics
 
 from QNodeEditor.themes import ThemeType, DarkTheme
+from QNodeEditor.graphics.entry import EntryGraphics
+from QNodeEditor.graphics.scene import NodeSceneGraphics
 if TYPE_CHECKING:
     from QNodeEditor.node import Node
     from QNodeEditor.entry import Entry
@@ -185,7 +192,9 @@ class NodeGraphics(QGraphicsItem):
         self._hovered = False
         self.update()
 
-    def itemChange(self, change: QGraphicsItem.GraphicsItemChange, value: QVariant) -> QVariant:
+    def itemChange(self, change: QGraphicsItem.GraphicsItemChange,
+                   value: int | QGraphicsItem | EntryGraphics | NodeSceneGraphics) \
+            -> int | QGraphicsItem | EntryGraphics | NodeSceneGraphics:
         """
         Update the node and connected edges if it was moved.
 

--- a/QNodeEditor/graphics/scene.py
+++ b/QNodeEditor/graphics/scene.py
@@ -5,9 +5,14 @@ Module containing extension of QGraphicsScene for node editor scenes.
 from math import floor, ceil
 from typing import TYPE_CHECKING
 
-from PyQt5.QtWidgets import QGraphicsScene, QWidget
-from PyQt5.QtCore import QRectF, QPoint
-from PyQt5.QtGui import QPainter, QPen
+try:
+    from PySide6.QtWidgets import QGraphicsScene, QWidget
+    from PySide6.QtCore import QRectF, QPoint
+    from PySide6.QtGui import QPainter, QPen
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsScene, QWidget
+    from PyQt5.QtCore import QRectF, QPoint
+    from PyQt5.QtGui import QPainter, QPen
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 if TYPE_CHECKING:

--- a/QNodeEditor/graphics/socket.py
+++ b/QNodeEditor/graphics/socket.py
@@ -4,9 +4,14 @@ Module containing extension of QGraphicsItem representing a socket.
 # pylint: disable = no-name-in-module, C0103
 from typing import TYPE_CHECKING
 
-from PyQt5.QtWidgets import QGraphicsItem
-from PyQt5.QtCore import QRectF, QPointF
-from PyQt5.QtGui import QPen, QBrush, QColor, QPainter
+try:
+    from PySide6.QtWidgets import QGraphicsItem
+    from PySide6.QtCore import QRectF, QPointF
+    from PySide6.QtGui import QPen, QBrush, QColor, QPainter
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsItem
+    from PyQt5.QtCore import QRectF, QPointF
+    from PyQt5.QtGui import QPen, QBrush, QColor, QPainter
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 if TYPE_CHECKING:

--- a/QNodeEditor/graphics/view.py
+++ b/QNodeEditor/graphics/view.py
@@ -6,9 +6,14 @@ from typing import Optional, Type, Iterable
 from math import sqrt
 from functools import partial
 
-from PyQt5.QtWidgets import QGraphicsView, QGraphicsItem, QMenu, QAction, QFrame
-from PyQt5.QtCore import Qt, QPoint, QRectF
-from PyQt5.QtGui import QPainter, QMouseEvent, QWheelEvent, QKeyEvent, QCursor, QContextMenuEvent
+try:
+    from PySide6.QtWidgets import QGraphicsView, QGraphicsItem, QMenu, QFrame
+    from PySide6.QtCore import Qt, QPoint, QRectF
+    from PySide6.QtGui import QAction, QPainter, QMouseEvent, QWheelEvent, QKeyEvent, QCursor, QContextMenuEvent
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsView, QGraphicsItem, QMenu, QAction, QFrame
+    from PyQt5.QtCore import Qt, QPoint, QRectF
+    from PyQt5.QtGui import QPainter, QMouseEvent, QWheelEvent, QKeyEvent, QCursor, QContextMenuEvent
 
 from QNodeEditor.node import Node
 from QNodeEditor.edge import Edge
@@ -67,7 +72,7 @@ class NodeView(QGraphicsView):
 
         # Set graphics rendering properties
         self.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
-        self.setRenderHints(QPainter.Antialiasing | QPainter.HighQualityAntialiasing |
+        self.setRenderHints(QPainter.Antialiasing | #QPainter.HighQualityAntialiasing |
                             QPainter.TextAntialiasing | QPainter.SmoothPixmapTransform)
 
         # Set viewport properties
@@ -764,7 +769,11 @@ class NodeView(QGraphicsView):
             None
         """
         for item in self.scene_graphics.selectedItems():
-            if isinstance(item, EdgeGraphics):
+            # For reasons unknown EdgeGraphics does not have _abc_impl which prevents the usage of isinstance().
+            # It might be related to the usage of a custom metaclass but further investigation is needed.
+            # The below workaround uses pythons subclass registration to check if the class item is from is a
+            # EdgeGraphics subclass
+            if item.__class__ == EdgeGraphics or item.__class__ in EdgeGraphics.__subclasses__():
                 item.edge.remove()
             elif isinstance(item, NodeGraphics):
                 item.node.remove()

--- a/QNodeEditor/metas/graphics_path_item.py
+++ b/QNodeEditor/metas/graphics_path_item.py
@@ -4,7 +4,10 @@ Metaclass for classes deriving from QGraphicsPathItem and ABC meta
 # pylint: disable = no-name-in-module
 from abc import ABCMeta
 
-from PyQt5.QtWidgets import QGraphicsPathItem
+try:
+    from PySide6.QtWidgets import QGraphicsPathItem
+except ImportError:
+    from PyQt5.QtWidgets import QGraphicsPathItem
 
 
 class GraphicsPathItemMeta(type(QGraphicsPathItem), ABCMeta):

--- a/QNodeEditor/metas/object.py
+++ b/QNodeEditor/metas/object.py
@@ -2,7 +2,10 @@
 Module containing metaclass for classes deriving from QObject and serializable
 """
 # pylint: disable = no-name-in-module
-from PyQt5.QtCore import QObject
+try:
+    from PySide6.QtCore import QObject
+except ImportError:
+    from PyQt5.QtCore import QObject
 
 from QNodeEditor.serialise import Serializable
 

--- a/QNodeEditor/node.py
+++ b/QNodeEditor/node.py
@@ -9,9 +9,15 @@ up the structure of the node and determine its look. Contains a graphics object 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Optional, Iterable, overload, Any, Type
 
-from PyQt5.QtWidgets import QCompleter
-from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtGui import QValidator
+try:
+    from PySide6.QtWidgets import QCompleter
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import QObject
+    from PySide6.QtGui import QValidator
+except ImportError:
+    from PyQt5.QtWidgets import QCompleter
+    from PyQt5.QtCore import pyqtSignal, QObject
+    from PyQt5.QtGui import QValidator
 
 from QNodeEditor.entry import Entry
 from QNodeEditor.graphics.node import NodeGraphics

--- a/QNodeEditor/socket.py
+++ b/QNodeEditor/socket.py
@@ -8,7 +8,12 @@ it.
 from __future__ import annotations
 from typing import TYPE_CHECKING, Type
 
-from PyQt5.QtCore import QObject, pyqtSignal
+try:
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import QObject
+except ImportError:
+    from PyQt5.QtCore import pyqtSignal, QObject
+
 
 from QNodeEditor.graphics.socket import SocketGraphics
 from QNodeEditor.metas import ObjectMeta

--- a/QNodeEditor/themes/dark.py
+++ b/QNodeEditor/themes/dark.py
@@ -1,7 +1,11 @@
 """Class containing dark theme for node editor"""
 # pylint: disable = no-name-in-module, R0801
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QColor
+except ImportError:
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtGui import QColor
 
 from QNodeEditor.themes.theme import Theme
 

--- a/QNodeEditor/themes/light.py
+++ b/QNodeEditor/themes/light.py
@@ -1,7 +1,11 @@
 """Class containing light theme for node editor"""
 # pylint: disable = no-name-in-module, R0801
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QColor
+except ImportError:
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtGui import QColor
 
 from QNodeEditor.themes.theme import Theme
 

--- a/QNodeEditor/themes/theme.py
+++ b/QNodeEditor/themes/theme.py
@@ -10,8 +10,12 @@ from typing import Type, Optional
 from pkgutil import get_data
 from pkg_resources import resource_filename
 
-from PyQt5.QtCore import QByteArray, Qt
-from PyQt5.QtGui import QColor, QFontDatabase, QFont
+try:
+    from PySide6.QtCore import QByteArray, Qt
+    from PySide6.QtGui import QColor, QFontDatabase, QFont
+except ImportError:
+    from PyQt5.QtCore import QByteArray, Qt
+    from PyQt5.QtGui import QColor, QFontDatabase, QFont
 
 
 class Theme:

--- a/QNodeEditor/util.py
+++ b/QNodeEditor/util.py
@@ -2,10 +2,16 @@
 # pylint: disable = no-name-in-module
 from typing import Any
 
-from PyQt5.QtWidgets import (QWidget, QCheckBox, QCalendarWidget, QColorDialog, QDateEdit,
-                             QDateTimeEdit, QTimeEdit, QDial, QDoubleSpinBox, QSpinBox, QComboBox,
-                             QFontComboBox, QKeySequenceEdit, QLineEdit, QListWidget,
-                             QPlainTextEdit, QRadioButton, QSlider, QTextEdit, QLayout)
+try:
+    from PySide6.QtWidgets import (QWidget, QCheckBox, QCalendarWidget, QColorDialog, QDateEdit,
+                                   QDateTimeEdit, QTimeEdit, QDial, QDoubleSpinBox, QSpinBox, QComboBox,
+                                   QFontComboBox, QKeySequenceEdit, QLineEdit, QListWidget,
+                                   QPlainTextEdit, QRadioButton, QSlider, QTextEdit, QLayout)
+except ImportError:
+    from PyQt5.QtWidgets import (QWidget, QCheckBox, QCalendarWidget, QColorDialog, QDateEdit,
+                                 QDateTimeEdit, QTimeEdit, QDial, QDoubleSpinBox, QSpinBox, QComboBox,
+                                 QFontComboBox, QKeySequenceEdit, QLineEdit, QListWidget,
+                                 QPlainTextEdit, QRadioButton, QSlider, QTextEdit, QLayout)
 
 from QNodeEditor.widgets import ComboBox, ValueBox, TextBox
 

--- a/QNodeEditor/widgets/combo_box.py
+++ b/QNodeEditor/widgets/combo_box.py
@@ -2,10 +2,18 @@
 Module containing custom combo box for selection inputs
 """
 # pylint: disable = no-name-in-module, C0103
-from PyQt5.QtWidgets import (QComboBox, QStyledItemDelegate, QStyleOptionViewItem, QApplication,
-                             QFrame, QSizePolicy)
-from PyQt5.QtCore import Qt, QModelIndex, QSize, QRect, QEvent, QObject, pyqtSignal
-from PyQt5.QtGui import QPainter, QPen, QFontMetrics
+
+try:
+    from PySide6.QtWidgets import (QComboBox, QStyledItemDelegate, QStyleOptionViewItem, QApplication,
+                                   QFrame, QSizePolicy)
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import Qt, QModelIndex, QSize, QRect, QEvent, QObject
+    from PySide6.QtGui import QPainter, QPen, QFontMetrics
+except ImportError:
+    from PyQt5.QtWidgets import (QComboBox, QStyledItemDelegate, QStyleOptionViewItem, QApplication,
+                                 QFrame, QSizePolicy)
+    from PyQt5.QtCore import Qt, QModelIndex, QSize, QRect, QEvent, QObject, pyqtSignal
+    from PyQt5.QtGui import QPainter, QPen, QFontMetrics
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 

--- a/QNodeEditor/widgets/empty.py
+++ b/QNodeEditor/widgets/empty.py
@@ -2,8 +2,12 @@
 Module containing empty QWidget
 """
 # pylint: disable = no-name-in-module
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import Qt
+try:
+    from PySide6.QtWidgets import QWidget
+    from PySide6.QtCore import Qt
+except ImportError:
+    from PyQt5.QtWidgets import QWidget
+    from PyQt5.QtCore import Qt
 
 
 class EmptyWidget(QWidget):

--- a/QNodeEditor/widgets/label.py
+++ b/QNodeEditor/widgets/label.py
@@ -2,7 +2,10 @@
 Module containing custom extension of QLabel with node editor theme
 """
 # pylint: disable = no-name-in-module
-from PyQt5.QtWidgets import QLabel
+try:
+    from PySide6.QtWidgets import QLabel
+except ImportError:
+    from PyQt5.QtWidgets import QLabel
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 

--- a/QNodeEditor/widgets/text_box.py
+++ b/QNodeEditor/widgets/text_box.py
@@ -3,10 +3,17 @@ Module containing custom line edit for text input
 """
 from typing import Optional
 
-from PyQt5.QtWidgets import (QLineEdit, QWidget, QStackedLayout, QLabel, QSizePolicy, QHBoxLayout,
-                             QCompleter)
-from PyQt5.QtCore import pyqtSignal, Qt
-from PyQt5.QtGui import QFocusEvent, QValidator
+try:
+    from PySide6.QtWidgets import (QLineEdit, QWidget, QStackedLayout, QLabel, QSizePolicy, QHBoxLayout,
+                                   QCompleter)
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QFocusEvent, QValidator
+except ImportError:
+    from PyQt5.QtWidgets import (QLineEdit, QWidget, QStackedLayout, QLabel, QSizePolicy, QHBoxLayout,
+                                 QCompleter)
+    from PyQt5.QtCore import pyqtSignal, Qt
+    from PyQt5.QtGui import QFocusEvent, QValidator
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 

--- a/QNodeEditor/widgets/value_box.py
+++ b/QNodeEditor/widgets/value_box.py
@@ -5,11 +5,19 @@ Module containing custom value box for number inputs with slide controls and lin
 from typing import Optional, Type
 from functools import partial
 
-from PyQt5.QtWidgets import (QLineEdit, QWidget, QPushButton, QHBoxLayout, QSizePolicy, QLabel,
-                             QApplication, QSpacerItem, QStackedLayout)
-from PyQt5.QtCore import QPoint, pyqtSignal, Qt, QObject, QEvent
-from PyQt5.QtGui import (QMouseEvent, QIntValidator, QDoubleValidator, QFocusEvent, QKeyEvent,
-                         QPalette, QColor, QEnterEvent)
+try:
+    from PySide6.QtWidgets import (QLineEdit, QWidget, QPushButton, QHBoxLayout, QSizePolicy, QLabel,
+                                   QApplication, QSpacerItem, QStackedLayout)
+    from PySide6.QtCore import Signal as pyqtSignal
+    from PySide6.QtCore import QPoint, Qt, QObject, QEvent
+    from PySide6.QtGui import (QMouseEvent, QIntValidator, QDoubleValidator, QFocusEvent, QKeyEvent,
+                               QPalette, QColor, QEnterEvent)
+except ImportError:
+    from PyQt5.QtWidgets import (QLineEdit, QWidget, QPushButton, QHBoxLayout, QSizePolicy, QLabel,
+                                 QApplication, QSpacerItem, QStackedLayout)
+    from PyQt5.QtCore import QPoint, pyqtSignal, Qt, QObject, QEvent
+    from PyQt5.QtGui import (QMouseEvent, QIntValidator, QDoubleValidator, QFocusEvent, QKeyEvent,
+                             QPalette, QColor, QEnterEvent)
 
 from QNodeEditor.themes import ThemeType, DarkTheme
 

--- a/examples/calculator/main.py
+++ b/examples/calculator/main.py
@@ -1,6 +1,9 @@
 import traceback
 
-from PyQt5.QtWidgets import QApplication
+try:
+    from PySide6.QtWidgets import QApplication
+except ImportError:
+    from PyQt5.QtWidgets import QApplication
 from QNodeEditor import NodeEditor, Edge
 
 from nodes import ConstantNode, OperationNode, OutputNode, SquareRootNode

--- a/examples/dialog/main.py
+++ b/examples/dialog/main.py
@@ -1,4 +1,7 @@
-from PyQt5.QtWidgets import QApplication, QMainWindow, QPushButton
+try:
+    from PySide6.QtWidgets import QApplication, QMainWindow, QPushButton
+except ImportError:
+    from PyQt5.QtWidgets import QApplication, QMainWindow, QPushButton
 
 from QNodeEditor import NodeEditorDialog
 from nodes import ConstantNode, OperationNode, OutputNode, SquareRootNode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyQt5~=5.15.10
 networkx~=3.2.1
+pyside6~=6.7.1


### PR DESCRIPTION
pyqt5 is a library written around the Qt library by Riverbanks Computing and NOT the Qt Project. pyside6 is the official Python library for Qt made by the Qt Project.

Furthermore, pyqt5 is based on Qt version 5.1.15 while pyside6 is written around Qt 6.4 which is the newest version of the Qt library as published by the Qt Project

For this pull request it was decided to still have pyqt5 as a fallback import option for existing projects but a warning will be emitted that support for pyqt5 could be removed at a later date.

known bugs:
- ComboBox popups do not render but are functional. It is currently not known why and how this happens
- isinstance and issubclass sometimes do not work and have to be replaced with workarounds. not all cases of this might have been found it is recommended to replace all of them
- a warning is emitted when the editing signal is disconnected