### PR TITLE
Combobox Entry Loading Fix

### DIFF
--- a/QNodeEditor/entries/combo_box.py
+++ b/QNodeEditor/entries/combo_box.py
@@ -106,7 +106,7 @@ class ComboBoxEntry(Entry):
             State of the combo box
         """
         return {
-            'currentData': self.widget.currentData()
+            'currentText': self.widget.currentText()
         }
 
     def load(self, state: dict) -> bool:
@@ -123,5 +123,6 @@ class ComboBoxEntry(Entry):
         bool
             Whether setting state succeeded
         """
-        self.widget.setCurrentIndex(self.widget.findData(state.get('currentData', self.widget.currentData())))
-        return True
+        currentIndex = self.widget.findText(state.get('currentText', self.widget.currentText()))
+        self.widget.setCurrentIndex(currentIndex)
+        return currentIndex != -1

--- a/QNodeEditor/entries/combo_box.py
+++ b/QNodeEditor/entries/combo_box.py
@@ -106,7 +106,7 @@ class ComboBoxEntry(Entry):
             State of the combo box
         """
         return {
-            'index': self.widget.currentIndex()
+            'currentData': self.widget.currentData()
         }
 
     def load(self, state: dict) -> bool:
@@ -123,5 +123,5 @@ class ComboBoxEntry(Entry):
         bool
             Whether setting state succeeded
         """
-        self.widget.setCurrentIndex(state.get('index', self.widget.currentIndex()))
+        self.widget.setCurrentIndex(self.widget.findData(state.get('currentData', self.widget.currentData())))
         return True


### PR DESCRIPTION
When using a dict to set the values of a combobox, the ordering of the dict may not be preserved when loading the data from a file in a new instance. Therefore, this pull request aims to use the data provided to the entry to determine the current index, mitigating this problem.