### PR TITLE
Fix Memory Leak Issue

### DIFF
--- a/QNodeEditor/themes/theme.py
+++ b/QNodeEditor/themes/theme.py
@@ -135,6 +135,9 @@ class Theme:
     socket_outline_width: float
     """float: Socket outline width"""
 
+    # cache font
+    fontCache: Optional[QFont] = None
+
     @classmethod
     def font(cls, point_size: Optional[int] = None) -> QFont:
         """
@@ -150,13 +153,17 @@ class Theme:
         QFont
             Loaded font
         """
-        # Add application font from resource file
-        data = QByteArray(get_data(__name__, f'fonts/{cls.font_name}'))
-        font_id = QFontDatabase.addApplicationFontFromData(data)
+        if cls.fontCache is not None:
+            font = QFont(cls.fontCache)
+        else:
+            # Add application font from resource file
+            data = QByteArray(get_data(__name__, f"fonts/{cls.font_name}"))
+            font_id = QFontDatabase.addApplicationFontFromData(data)
 
-        # Create a QFont from the font ID
-        font_family = QFontDatabase.applicationFontFamilies(font_id)[0]
-        font = QFont(font_family)
+            # Create a QFont from the font ID
+            font_family = QFontDatabase.applicationFontFamilies(font_id)[0]
+            font = QFont(font_family)
+            cls.fontCache = font
 
         # Set point size if specified, or use default size
         if point_size is not None:
@@ -164,6 +171,7 @@ class Theme:
         else:
             font.setPointSize(cls.font_size)
         return font
+
 
     @classmethod
     def load_svg(cls, filename: str) -> str:


### PR DESCRIPTION
This fixes #22 

Due to the font getting loaded each time a node is created (I think), this created a lot of (unnecessary) duplicates in the QFontDatabase. This PR implements a cache for the Font, so it only has to be loaded once for a Theme.